### PR TITLE
perf: Only install dependencies instead of build the package from source when checking

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -29,9 +29,8 @@ echo "::endgroup::"
 echo "::group::Get native dependencies"
 # R -e "install.packages(sub('_.*', '', '${SOURCEPKG}'), depends=TRUE)" || true
 
-# (Re)build linux native binary (also ensures dev-deps are present)
-# This is expensive, maybe we should copy the binary from the previous job
-R -e "pak::pak('./${SOURCEPKG}')"
+# Ensures dev-deps are present
+R -e "pak::local_install_dev_deps('./${SOURCEPKG}')"
 echo "::endgroup::"
 
 # Compile WASM binary


### PR DESCRIPTION
After an update requesting a new Rust version, I noticed that this workflow builds the package twice (and failed).

https://github.com/r-universe/eitsupi/actions/runs/13803060730

I have added a workaround to the package to install the new Rust version using rustup during the Emscripten build[^1], but obviously there is a normal Linux package build going on here that is difficult to detect.
Perhaps the purpose of this line is to make sure that the dependencies are installable from the R-universe, so isn't this enough?

[^1]: <https://github.com/eitsupi/neo-r-polars/blob/5520c5c3e533ca48b27583e4deae320600f104de/configure#L3-L16>