### PR TITLE
fix: update Rust if rust in sysreqs

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -26,6 +26,12 @@ echo "::group::Test that pkg-config works"
 PKG_CONFIG_LIBDIR="${WEBR_ROOT}/wasm/lib/pkgconfig" pkg-config --libs --cflags gdal
 echo "::endgroup::"
 
+if [[ "$(Rscript -e 'if ("rust" %in% pak::pkg_sysreqs(".")$packages$sysreq) cat("true")')" == "true" ]]; then
+  echo "::group::Update Rust"
+  rustup update
+  echo "::endgroup::"
+fi
+
 echo "::group::Get native dependencies"
 # R -e "install.packages(sub('_.*', '', '${SOURCEPKG}'), depends=TRUE)" || true
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -29,6 +29,7 @@ echo "::endgroup::"
 if [[ "$(Rscript -e 'if ("rust" %in% pak::pkg_sysreqs(".")$packages$sysreq) cat("true")')" == "true" ]]; then
   echo "::group::Update Rust"
   rustup update
+  rustup update nightly
   echo "::endgroup::"
 fi
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -28,8 +28,7 @@ echo "::endgroup::"
 
 if [[ "$(Rscript -e 'if ("rust" %in% pak::pkg_sysreqs(".")$packages$sysreq) cat("true")')" == "true" ]]; then
   echo "::group::Update Rust"
-  rustup update
-  rustup update nightly
+  rustup update stable nightly
   echo "::endgroup::"
 fi
 


### PR DESCRIPTION
As I posted at https://github.com/r-universe-org/build-wasm/pull/2#issuecomment-2726298137, since Rust in containers becomes outdated over time, it would make sense to update Rust for packages that need it.