### PR TITLE
fix: allow failure of building linux native binary

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,8 +5,6 @@ on:
     branches: [master]
   workflow_dispatch:
     branches: [master]
-  schedule:
-    - cron: "0 2 * * *"
 
 jobs:
   build:

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,10 +41,9 @@ COPY Renviron /opt/R/current/lib/R/etc/Renviron.site
 COPY Rprofile /opt/R/current/lib/R/etc/Rprofile.site
 
 # Update emscripten rust from the parent container
-RUN rustup update stable
-
 # Workaround for https://github.com/rust-lang/rustup/issues/2417
-## RUN rustup toolchain uninstall nightly && rustup toolchain install nightly
+RUN rustup update stable &&\
+	rustup toolchain uninstall nightly && rustup toolchain install nightly
 
 # Use devel-pak (until solver hangs are fixed)
 RUN R -e 'install.packages("pak", lib = .Library, repos = "https://r-lib.github.io/p/pak/devel/source/linux-gnu/x86_64")'

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,8 @@ FROM ghcr.io/r-wasm/webr:main
 # Alternative workaround for libnode-dev conflicting with nodejs (see above)
 RUN apt-get update && \
 	apt-get install -y equivs lsb-release
+
+
 #	equivs-control libnode-dev && \
 #	sed -i 's/Package:.*/Package: libnode-dev/' libnode-dev && \
 #	sed -i 's/# Provides:.*/Provides: libv8-dev/' libnode-dev && \
@@ -39,11 +41,6 @@ ENV R_LIBS_USER=/opt/R/current/lib/R/site-library
 # Set CRAN repo
 COPY Renviron /opt/R/current/lib/R/etc/Renviron.site
 COPY Rprofile /opt/R/current/lib/R/etc/Rprofile.site
-
-# Update emscripten rust from the parent container
-# Workaround for https://github.com/rust-lang/rustup/issues/2417
-RUN rustup update stable &&\
-	rustup toolchain uninstall nightly && rustup toolchain install nightly
 
 # Use devel-pak (until solver hangs are fixed)
 RUN R -e 'install.packages("pak", lib = .Library, repos = "https://r-lib.github.io/p/pak/devel/source/linux-gnu/x86_64")'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -31,7 +31,7 @@ echo "::group::Get native dependencies"
 
 # (Re)build linux native binary (also ensures dev-deps are present)
 # This is expensive, maybe we should copy the binary from the previous job
-R -e "pak::pak('./${SOURCEPKG}')"
+R -e "pak::pak('./${SOURCEPKG}')" || true
 echo "::endgroup::"
 
 # Compile WASM binary

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -13,7 +13,7 @@ GITHUB_OUTPUT=${GITHUB_OUTPUT:-/dev/stdout}
 # Make sure we have laste rust
 if [ "$NEED_CARGO" ]; then
   echo "::group::Update Rust"
-  rustup update stable || true
+  rustup update stable nightly || true
   echo "::endgroup::"
 fi
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -10,13 +10,6 @@ echo "Running fake X server on $DISPLAY"
 SOURCEPKG="${1:-$SOURCEPKG}"
 GITHUB_OUTPUT=${GITHUB_OUTPUT:-/dev/stdout}
 
-# Make sure we have laste rust
-if [ "$NEED_CARGO" ]; then
-  echo "::group::Update Rust"
-  rustup update stable nightly || true
-  echo "::endgroup::"
-fi
-
 # Use package cache dir
 export R_LIBS_USER="${PWD}/pkglib"
 


### PR DESCRIPTION
Ref: https://github.com/r-universe-org/build-wasm/pull/4#issuecomment-2741162559

The issue here is that native binaries may be required, but since subsequent Emscripten builds may succeed without them in fact (which is the case for the original Rust dependency package), we can simply allow the build to fail.